### PR TITLE
Add a new command - brute

### DIFF
--- a/cmd/brute.go
+++ b/cmd/brute.go
@@ -262,7 +262,6 @@ func doJavaScriptRequestsLoop(urls []string, client *http.Client) (bool, map[str
 }
 
 var outputSpecFile string
-var target string = swaggerURL
 var bruteCmd = &cobra.Command{
 	Use:   "brute",
 	Short: "Sends a series of automated requests to discover the spec file.",
@@ -274,6 +273,7 @@ This will first check for specfiles embedded within javascript and then continue
 		client.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
+		var target string = swaggerURL
 
 		javascriptUrls := makeUrls(target, swaggerPrefixDirs, swaggerJavascriptEndpoints, ".js")
 		specFound, apiDoc := doJavaScriptRequestsLoop(javascriptUrls, client)

--- a/cmd/brute.go
+++ b/cmd/brute.go
@@ -1,0 +1,339 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	swaggerPrefixDirs = []string{
+		"/docs",
+		"",
+		"/swagger",
+		"/swagger/v1",
+		"/swagger/v2",
+		"/swagger/v3",
+		"/swagger/static",
+		"/swagger/ui",
+		"/swagger-ui",
+		"/api-docs",
+		"/api-docs/v1",
+		"/api-docs/v2",
+		"/apidocs",
+		"/api",
+		"/api/v1",
+		"/api/v2",
+		"/api/v3",
+		"/v1",
+		"/v2",
+		"/v3",
+		"/doc",
+		"/docs/swagger",
+		"/docs/swagger/v1",
+		"/docs/swagger/v2",
+		"/docs/swagger-ui",
+		"/docs/swagger-ui/v1",
+		"/docs/swagger-ui/v2",
+		"/docs/v1",
+		"/docs/v2",
+		"/docs/v3",
+		"/graphql",
+	}
+	swaggerFileExtensions = []string{
+		"",
+		"/",
+		".json",
+		".html",
+		".yaml",
+		".yml",
+	}
+	swaggerJsonEndpoints = []string{
+		"",
+		"/index",
+		"/swagger",
+		"/swagger-ui",
+		"/swagger-resources",
+		"/swagger-config",
+		"/openapi",
+		"/api",
+		"/api-docs",
+		"/apidocs",
+		"/v1",
+		"/v2",
+		"/v3",
+		"/doc",
+		"/docs",
+		"/graphql",
+		"/apispec",
+		"/apispec_1",
+	}
+	swaggerJavascriptEndpoints = []string{
+		"/swagger-ui-init",
+		"/swagger-ui-bundle",
+		"/swagger-ui-standalone-preset",
+		"/swagger-ui",
+		"/swagger-ui.min",
+		"/swagger-ui-es-bundle-core",
+		"/swagger-ui-es-bundle",
+		"/swagger-ui-standalone-preset",
+		"/swagger-ui-layout",
+		"/swagger-ui-plugins",
+	}
+	userAgents = []string{
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0",
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:73.0) Gecko/20100101 Firefox/73.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:74.0) Gecko/20100101 Firefox/74.0",
+		"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Safari/605.1.15",
+		"Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:76.0) Gecko/20100101 Firefox/76.0",
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/54.0",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) Gecko/20100101 Firefox/78.0",
+	}
+)
+
+func getRandomUserAgent() string {
+	rand.Seed(time.Now().UnixNano())
+	return userAgents[rand.Intn(len(userAgents))]
+}
+
+func makeUrls(target string, prefixDirs []string, endpoints []string, fileExtension string) []string {
+	urls := []string{}
+	for _, i1 := range prefixDirs {
+		for _, i2 := range endpoints {
+			if i1 == "" && i2 == "" {
+				continue
+			}
+			targetURL := target + i1 + i2 + fileExtension
+			urls = append(urls, targetURL)
+
+		}
+	}
+	return urls
+}
+
+func makeRequests(urls []string, client *http.Client, contentTypeToFind string) <-chan *http.Response {
+	responses := make(chan *http.Response)
+	go func() {
+		defer close(responses)
+		requestCount := 1
+		fmt.Printf("[*] SEARCHING FOR Content-Type == %s\n", contentTypeToFind)
+		for _, url := range urls {
+			fmt.Printf("[*] Request #%d: \t%s\n", requestCount, url)
+			req, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				log.Printf("[!] Error creating request for %s: %v", url, err)
+				continue
+			}
+			req.Header.Set("User-Agent", getRandomUserAgent())
+			resp, err := client.Do(req)
+			if err != nil {
+				log.Printf("[!] Error fetching %s: %v", url, err)
+				continue
+			}
+			//defer resp.Body.Close() // Ensure the body is closed after reading
+			if resp.StatusCode == 200 {
+				contentType := strings.Split(resp.Header.Get("Content-Type"), ";")[0]
+				if contentType == contentTypeToFind {
+					fmt.Printf("[*] FOUND %s:\t%s\n", contentTypeToFind, url)
+					//responses <- resp
+
+					var responseSize int
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						fmt.Println("Error reading body:", err)
+						continue
+					}
+					responseSize = len(body)
+					fmt.Printf("[*] Response length: %d bytes\n", responseSize)
+
+					if responseSize >= 8 {
+						// Create a new ReadCloser with the original body content
+						resp.Body = ioutil.NopCloser(strings.NewReader(string(body)))
+						responses <- resp
+					} else {
+						resp.Body.Close() // Close the body if the response size is too small
+					}
+				} else {
+					resp.Body.Close() // Close the body if content type does not match
+				}
+			} else {
+				resp.Body.Close() // Close the body if status code is not 200
+			}
+			requestCount++
+		}
+	}()
+	return responses
+}
+
+func lookForSpecIndicator(response *http.Response) bool {
+	var jsonResponse map[string]interface{}
+	if err := json.NewDecoder(response.Body).Decode(&jsonResponse); err != nil {
+		return false
+	}
+	if _, ok := jsonResponse["openapi"]; ok {
+		return true
+	}
+	if _, ok := jsonResponse["swagger"]; ok {
+		return true
+	}
+	return false
+}
+
+func lookForSpecIndicatorJavaScript(response *http.Response) (bool, map[string]interface{}) {
+	defer response.Body.Close() // Ensure the body is closed after reading
+	//regexPattern := regexp.MustCompile(`let\s+(\w+)\s*=\s*({.*?});`)
+	regexPattern := regexp.MustCompile(`(?s)let\s+(\w+)\s*=\s*({.*?});`)
+
+	jsContent, err := io.ReadAll(response.Body)
+	//fmt.Println(string(jsContent))
+	if err != nil {
+		log.Printf("Error reading response body: %v", err)
+		return false, nil
+	}
+
+	matches := regexPattern.FindAllStringSubmatch(string(jsContent), -1)
+	for _, match := range matches {
+		jsonContent := match[2]
+		var rawData map[string]interface{}
+		if err := json.Unmarshal([]byte(jsonContent), &rawData); err != nil {
+			continue
+		}
+		rawDataKeys := make([]string, 0, len(rawData))
+		for key := range rawData {
+			rawDataKeys = append(rawDataKeys, key)
+		}
+
+		if len(rawDataKeys) != 0 {
+			data := rawData[rawDataKeys[0]].(map[string]interface{})
+			if _, ok := data["openapi"]; ok {
+				return true, data
+			}
+			if _, ok := data["swagger"]; ok {
+				return true, data
+			}
+		}
+	}
+	return false, nil
+}
+
+func doJsonRequestsLoop(urls []string, client *http.Client) bool {
+	for response := range makeRequests(urls, client, "application/json") {
+		if response != nil && lookForSpecIndicator(response) {
+			fmt.Printf("[*] SPEC FILE FOUND:\t%s\n", response.Request.URL)
+			return true
+		}
+	}
+	return false
+}
+
+func doJavaScriptRequestsLoop(urls []string, client *http.Client) (bool, map[string]interface{}) {
+	for response := range makeRequests(urls, client, "application/javascript") {
+		if response != nil {
+			isSpec, apiDoc := lookForSpecIndicatorJavaScript(response)
+			if isSpec {
+				fmt.Printf("[*] FOUND SPEC embedded in JavaScript file:\t%s\n", response.Request.URL)
+				return true, apiDoc
+			}
+		}
+	}
+	return false, nil
+}
+
+var outputSpecFile string
+var target string
+var bruteCmd = &cobra.Command{
+	Use:   "brute",
+	Short: "Sends a series of automated requests to discover the spec file.",
+	Long: `The automate command sends a request to the target to find the spec file based on historic file locations.
+This enables the user to get a quick look at which endpoints require authentication and which ones do not. If a request
+responds in an abnormal way, manual testing should be conducted (prepare manual tests using the "prepare" command).`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		client := &http.Client{}
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+
+		javascriptUrls := makeUrls(target, swaggerPrefixDirs, swaggerJavascriptEndpoints, ".js")
+		specFound, apiDoc := doJavaScriptRequestsLoop(javascriptUrls, client)
+		if specFound {
+			file, err := json.MarshalIndent(apiDoc, "", "  ")
+			if err != nil {
+				log.Fatalf("Error marshalling API doc: %v", err)
+			}
+			if err := ioutil.WriteFile(outputSpecFile, file, 0644); err != nil {
+				log.Fatalf("Error writing to file: %v", err)
+			}
+			return
+		}
+
+		jsonUrls := makeUrls(target, swaggerPrefixDirs, swaggerJsonEndpoints, ".json")
+		if doJsonRequestsLoop(jsonUrls, client) {
+			return
+		}
+
+		blankUrls := makeUrls(target, swaggerPrefixDirs, swaggerJsonEndpoints, "")
+		if doJsonRequestsLoop(blankUrls, client) {
+			return
+		}
+
+		htmlUrls := makeUrls(target, swaggerPrefixDirs, swaggerJsonEndpoints, ".html")
+		if doJsonRequestsLoop(htmlUrls, client) {
+			return
+		}
+
+		// Not sure if YAML and YML files will need to be processed differently... could exclude these.
+		yamlUrls := makeUrls(target, swaggerPrefixDirs, swaggerJsonEndpoints, ".yaml")
+		if doJsonRequestsLoop(yamlUrls, client) {
+			return
+		}
+
+		ymlUrls := makeUrls(target, swaggerPrefixDirs, swaggerJsonEndpoints, ".yml")
+		if doJsonRequestsLoop(ymlUrls, client) {
+			return
+		}
+
+		slashUrls := makeUrls(target, swaggerPrefixDirs, swaggerJsonEndpoints, "/")
+		if doJsonRequestsLoop(slashUrls, client) {
+			return
+		}
+		// Should maybe add code to just copy the specfile locally even if it is found to just be a json file because it will make automating easier.
+
+		// Should add a flag here to check if automate is true and if so than call the 'sj automate' function with the specfile that is copied locally.
+
+	},
+}
+
+func init() {
+	bruteCmd.PersistentFlags().StringVarP(&outputSpecFile, "outfile", "o", "spec_file.json", "Output the results to a file. This defaults to a JSON file unless an output format (-F) is specified.")
+	bruteCmd.PersistentFlags().StringVarP(&target, "target", "x", "", "The target you want to perform brute force spec finding on.")
+	//Should add a flag here called something like 'automate' which is a boolean that defaults to false. But when present it is set to true and then it will cause the program to do 'sj automate' on the found spec file automatically.
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ $ sj endpoints -u https://petstore.swagger.io/v2/swagger.json`,
 			log.Error("Command not specified. See the --help flag for usage.")
 		}
 	},
-	Version: "1.1.1",
+	Version: "1.3.0",
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ func init() {
 	rootCmd.AddCommand(automateCmd)
 	rootCmd.AddCommand(endpointsCmd)
 	rootCmd.AddCommand(prepareCmd)
+	rootCmd.AddCommand(bruteCmd)
 	rootCmd.PersistentFlags().StringVarP(&UserAgent, "agent", "a", "Swagger Jacker (github.com/BishopFox/sj)", "Set the User-Agent string.")
 	rootCmd.PersistentFlags().StringVarP(&basePath, "base-path", "b", "", "Set the API base path if not defined in the spec (i.e. /V2/)")
 	rootCmd.PersistentFlags().StringVarP(&format, "format", "f", "json", "Declare the format of the documentation (json/yaml/yml/js).")


### PR DESCRIPTION
This is the start of a new command called `brute` which will brute force requests on a target to look for a valid specfile without having to pass in a URL that points at an existing swagger endpoint (such as the swagger interface). This added code is able to find and parse a specfile that is embedded within javascript as a variable. It is also able to find raw JSON specfiles. 

TODO:
- Add YAML parsing
- Add ability to pass in a `automate` flag to tell the code to then run `sj automate` on a found specfile
- Add ability to multiprocess requests across multiple targets at once (as passed in as a command line argument to a file with a list of targets or a delimited string of targets).
- Add ability to save JSON specfiles locally if desired (javascript extracted specfiles are already being saved).