### PR TITLE
Fix for issue #6 - Handle Bearer tokens correctly

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ $ sj brute -u https://petstore.swagger.io`,
 			log.Error("Command not specified. See the --help flag for usage.")
 		}
 	},
-	Version: "1.4.5",
+	Version: "1.4.6",
 }
 
 func Execute() {


### PR DESCRIPTION
#### Card

#### Details

 A fix for issue #6 to handle Bearer token authentication correctly


```
 » ./sj prepare -l api.json -T https://test.local

INFO[0000] Gathering API details.
                      
INFO[0000] Available authentication mechanisms:         
    - bearer
INFO[0000] A bearer token is accepted. Would you like to provide one? (y/N) 
y
What value would you like to use for the Bearer Token?ABCDEF

Title: API.
curl -sk -X GET 'https://test.local/api?type=test' -H 'Authorization: Bearer ABCDEF'
curl -sk -X POST 'https://test.local/api/settings' -H 'Authorization: Bearer ABCDEF'
```