### PR TITLE
Resolved nil pointer dereference

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ $ sj convert -u https://petstore.swagger.io/v2/swagger.json -o openapi.json`,
 			log.Error("Command not specified. See the --help flag for usage.")
 		}
 	},
-	Version: "1.8.2",
+	Version: "1.8.4",
 }
 
 func Execute() {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -317,7 +317,7 @@ func (s SwaggerRequest) AddParametersToRequest(op *openapi3.Operation) SwaggerRe
 		}
 	}
 
-	if op.RequestBody != nil {
+	if op.RequestBody.Value != nil {
 		if op.RequestBody.Value.Content != nil {
 			for i := range op.RequestBody.Value.Content {
 				if contentType == "" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -317,115 +317,117 @@ func (s SwaggerRequest) AddParametersToRequest(op *openapi3.Operation) SwaggerRe
 		}
 	}
 
-	if op.RequestBody.Value != nil {
-		if op.RequestBody.Value.Content != nil {
-			for i := range op.RequestBody.Value.Content {
-				if contentType == "" {
-					EnforceSingleContentType(i)
-				} else {
-					EnforceSingleContentType(contentType)
-				}
-				if op.RequestBody.Value.Content.Get(i).Schema != nil {
-					if op.RequestBody.Value.Content.Get(i).Schema.Value == nil {
-						s = s.SetParametersFromSchema(nil, "body", op.RequestBody.Value.Content.Get(i).Schema.Ref, op.RequestBody, 0)
-						if strings.Contains(i, "json") {
-							s.BodyData, _ = json.Marshal(s.Body)
-						} else if strings.Contains(i, "x-www-form-urlencoded") {
-							var formData []string
-							for j := range s.Body {
-								formData = append(formData, fmt.Sprintf("%s=%s", j, fmt.Sprint(s.Body[j])))
-							}
-							s.BodyData = []byte(strings.Join(formData, "&"))
-						} else if strings.Contains(i, "xml") {
-							type Element struct {
-								XMLName xml.Name
-								Content any `xml:",chardata"`
-							}
-
-							type Root struct {
-								XMLName  xml.Name  `xml:"root"`
-								Elements []Element `xml:",any"`
-							}
-
-							var elements []Element
-							for key, value := range s.Body {
-								elements = append(elements, Element{
-									XMLName: xml.Name{Local: key},
-									Content: value,
-								})
-							}
-
-							root := Root{
-								Elements: elements,
-							}
-
-							xmlData, err := xml.Marshal(root)
-							if err != nil {
-								log.Warn("Error marshalling XML data.")
-							}
-							s.BodyData = xmlData
-						} else {
-							log.Warnf("Content type not supported. Test this path manually: %s (Content type: %s)\n", s.URL.Path, i)
-						}
+	if op.RequestBody != nil {
+		if op.RequestBody.Value != nil {
+			if op.RequestBody.Value.Content != nil {
+				for i := range op.RequestBody.Value.Content {
+					if contentType == "" {
+						EnforceSingleContentType(i)
 					} else {
-						var formData []string
-
-						for j := range op.RequestBody.Value.Content.Get(i).Schema.Value.Properties {
-							if op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Ref != "" {
-								s = s.SetParametersFromSchema(nil, "body", op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Ref, op.RequestBody, 0)
-							} else {
-								var valueType string = op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Value.Type
-								if op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Value != nil {
-									if valueType == "string" {
-										s.Body[j] = "test"
-									} else if valueType == "boolean" {
-										s.Body[j] = false
-									} else if valueType == "integer" || valueType == "number" {
-										s.Body[j] = 1
-									} else {
-										s.Body[j] = "unknown_type_populate_manually"
-									}
-									if i == "application/x-www-form-urlencoded" {
-										formData = append(formData, fmt.Sprintf("%s=%s", j, fmt.Sprint(s.Body[j])))
-									}
+						EnforceSingleContentType(contentType)
+					}
+					if op.RequestBody.Value.Content.Get(i).Schema != nil {
+						if op.RequestBody.Value.Content.Get(i).Schema.Value == nil {
+							s = s.SetParametersFromSchema(nil, "body", op.RequestBody.Value.Content.Get(i).Schema.Ref, op.RequestBody, 0)
+							if strings.Contains(i, "json") {
+								s.BodyData, _ = json.Marshal(s.Body)
+							} else if strings.Contains(i, "x-www-form-urlencoded") {
+								var formData []string
+								for j := range s.Body {
+									formData = append(formData, fmt.Sprintf("%s=%s", j, fmt.Sprint(s.Body[j])))
+								}
+								s.BodyData = []byte(strings.Join(formData, "&"))
+							} else if strings.Contains(i, "xml") {
+								type Element struct {
+									XMLName xml.Name
+									Content any `xml:",chardata"`
 								}
 
-								if i == "application/x-www-form-urlencoded" {
-									s.BodyData = []byte(strings.Join(formData, "&"))
-								} else if strings.Contains(i, "json") || i == "*/*" {
-									s.BodyData, _ = json.Marshal(s.Body)
-								} else if strings.Contains(i, "xml") {
-									//
-									type Element struct {
-										XMLName xml.Name
-										Content any `xml:",chardata"`
-									}
+								type Root struct {
+									XMLName  xml.Name  `xml:"root"`
+									Elements []Element `xml:",any"`
+								}
 
-									type Root struct {
-										XMLName  xml.Name  `xml:"root"`
-										Elements []Element `xml:",any"`
-									}
+								var elements []Element
+								for key, value := range s.Body {
+									elements = append(elements, Element{
+										XMLName: xml.Name{Local: key},
+										Content: value,
+									})
+								}
 
-									var elements []Element
-									for key, value := range s.Body {
-										elements = append(elements, Element{
-											XMLName: xml.Name{Local: key},
-											Content: value,
-										})
-									}
+								root := Root{
+									Elements: elements,
+								}
 
-									root := Root{
-										Elements: elements,
-									}
+								xmlData, err := xml.Marshal(root)
+								if err != nil {
+									log.Warn("Error marshalling XML data.")
+								}
+								s.BodyData = xmlData
+							} else {
+								log.Warnf("Content type not supported. Test this path manually: %s (Content type: %s)\n", s.URL.Path, i)
+							}
+						} else {
+							var formData []string
 
-									xmlData, err := xml.Marshal(root)
-									if err != nil {
-										log.Warn("Error marshalling XML data.")
-									}
-									s.BodyData = xmlData
+							for j := range op.RequestBody.Value.Content.Get(i).Schema.Value.Properties {
+								if op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Ref != "" {
+									s = s.SetParametersFromSchema(nil, "body", op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Ref, op.RequestBody, 0)
 								} else {
-									s.Body["test"] = "test"
-									s.BodyData = []byte("test=test")
+									var valueType string = op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Value.Type
+									if op.RequestBody.Value.Content.Get(i).Schema.Value.Properties[j].Value != nil {
+										if valueType == "string" {
+											s.Body[j] = "test"
+										} else if valueType == "boolean" {
+											s.Body[j] = false
+										} else if valueType == "integer" || valueType == "number" {
+											s.Body[j] = 1
+										} else {
+											s.Body[j] = "unknown_type_populate_manually"
+										}
+										if i == "application/x-www-form-urlencoded" {
+											formData = append(formData, fmt.Sprintf("%s=%s", j, fmt.Sprint(s.Body[j])))
+										}
+									}
+
+									if i == "application/x-www-form-urlencoded" {
+										s.BodyData = []byte(strings.Join(formData, "&"))
+									} else if strings.Contains(i, "json") || i == "*/*" {
+										s.BodyData, _ = json.Marshal(s.Body)
+									} else if strings.Contains(i, "xml") {
+										//
+										type Element struct {
+											XMLName xml.Name
+											Content any `xml:",chardata"`
+										}
+
+										type Root struct {
+											XMLName  xml.Name  `xml:"root"`
+											Elements []Element `xml:",any"`
+										}
+
+										var elements []Element
+										for key, value := range s.Body {
+											elements = append(elements, Element{
+												XMLName: xml.Name{Local: key},
+												Content: value,
+											})
+										}
+
+										root := Root{
+											Elements: elements,
+										}
+
+										xmlData, err := xml.Marshal(root)
+										if err != nil {
+											log.Warn("Error marshalling XML data.")
+										}
+										s.BodyData = xmlData
+									} else {
+										s.Body["test"] = "test"
+										s.BodyData = []byte("test=test")
+									}
 								}
 							}
 						}


### PR DESCRIPTION
#### Details

This resolves a nil pointer dereference error in cmd/utils.go.

#### Stack Trace

```bash
❯ ./sj endpoints -f yml -l EXAMPLE.yml

INFO[0000] Gathering endpoints.


panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x7e5032]

goroutine 1 [running]:
github.com/BishopFox/sj/cmd.SwaggerRequest.AddParametersToRequest({{0x0, 0x0}, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0xc00019b140, {0x0, 0x0, ...}, ...}, ...)
        /root/repos/sj/cmd/utils.go:321 +0x612
github.com/BishopFox/sj/cmd.SwaggerRequest.BuildDefinedRequests({{0x0, 0x0}, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0xc00019b140, {0x0, 0x0, ...}, ...}, ...)
        /root/repos/sj/cmd/utils.go:182 +0x1e5
github.com/BishopFox/sj/cmd.SwaggerRequest.IterateOverPaths({{0x0, 0x0}, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0, ...}, ...}, ...)
        /root/repos/sj/cmd/utils.go:164 +0x629
github.com/BishopFox/sj/cmd.GenerateRequests({0xc000172000?, 0xc0000ba250?, 0x0?}, {{0x96aac0, 0xc0000feb40}, 0x8f4188, {0x0, 0x0}, 0x0})
        /root/repos/sj/cmd/utils.go:106 +0x4fe
github.com/BishopFox/sj/cmd.init.func5(0xc000120a00?, {0x8ac4ed?, 0x4?, 0x8ac4f1?})
        /root/repos/sj/cmd/endpoints.go:36 +0x285
github.com/spf13/cobra.(*Command).execute(0xc20140, {0xc0000aa880, 0x4, 0x4})
        /root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x867
github.com/spf13/cobra.(*Command).ExecuteC(0xc1fb80)
        /root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/BishopFox/sj/cmd.Execute()
        /root/repos/sj/cmd/root.go:55 +0x1a
main.main()
        /root/repos/sj/main.go:6 +0xf
```
