### PR TITLE
Added failsafe check for Swaggers with no security definitions

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -23,6 +23,13 @@ var (
 
 func CheckSecDefs(doc3 openapi3.T) (apiInQuery bool, apiKey string, apiKeyName string) {
 
+    	if doc3.Components == nil || doc3.Components.SecuritySchemes == nil || len(doc3.Components.SecuritySchemes) == 0 {
+	        if !quiet {
+            		log.Warn("No security schemes defined in the OpenAPI specification.")
+        	}
+        	return false, "", ""
+    	}
+	
 	if outputFormat == "json" && !quiet {
 		if len(doc3.Components.SecuritySchemes) != 0 {
 			log.Warnf("The following authentication mechanisms are supported. If necessary, supply these manually when using the JSON output format:\n")


### PR DESCRIPTION
When a swagger file does not provide a security definition the tool crashes, now it gives a warning and continues

The error before the fix:

![Image](https://github.com/user-attachments/assets/cf49784b-b34f-4096-b5b5-4f0374bc53b0)

After the fix:

![Image](https://github.com/user-attachments/assets/6e8e7432-5b7b-44fd-a3c2-787ea134d3db)
