### PR TITLE
Fix EnforceSingleContentType function to not remove all custom headers

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ $ sj convert -u https://petstore.swagger.io/v2/swagger.json -o openapi.json`,
 			log.Error("Command not specified. See the --help flag for usage.")
 		}
 	},
-	Version: "1.10.1",
+	Version: "1.10.2",
 }
 
 func Execute() {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -672,22 +672,16 @@ func ExtractSpecFromJS(bodyBytes []byte) []byte {
 
 func EnforceSingleContentType(newContentType string) {
 	newContentType = strings.TrimSpace(newContentType)
-	if Headers != nil {
-		headerString := strings.Join(Headers, ",")
-		Headers = nil
-		ctIndex := strings.Index(strings.ToLower(headerString), "content-type:") + 14
-		headerString = headerString[ctIndex:]
-		if strings.Contains(headerString, ",") {
-			headerString = strings.TrimPrefix(headerString, ",")
-			ctEndIndex := strings.Index(headerString[ctIndex:], ",") + 1
-			headerString = headerString[:ctEndIndex]
-		} else if !strings.Contains(headerString, ":") {
-			headerString = ""
-		}
-		if headerString != "" {
-			Headers = append(Headers, strings.Split(headerString, ",")...)
-		}
-	}
+
+	// Remove old 'Content-Type' header
+	slices.DeleteFunc(Headers, func(h string) bool {
+		return strings.HasPrefix(strings.ToLower(h), "content-type:")
+	})
 
 	Headers = append(Headers, "Content-Type: "+newContentType)
+
+	// Remove empty elements to avoid repetitions of "-H ''"
+	Headers = slices.DeleteFunc(Headers, func(h string) bool {
+		return strings.TrimSpace(h) == ""
+	})
 }


### PR DESCRIPTION
As of now, if you run `sj` with custom headers, they would show up inconsistently, probably only in the first request.

```bash
$ sj prepare -u https://petstore.swagger.io/v2/swagger.json -q -r 10 -H "CustomHeader: Hello"

<SNIP>

curl -sk -X GET 'https://petstore.swagger.io/v2/pet/1' -H 'CustomHeader: Hello'
curl -sk -X POST 'https://petstore.swagger.io/v2/pet/1' -d 'name=test&status=test' -H 'Content-Type: application/x-www-form-urlencoded'
curl -sk -X POST 'https://petstore.swagger.io/v2/user' -d '{"email":"test","firstName":"test","id":1,"lastName":"test","password":"test","phone":"test","userStatus":1,"username":"test"}' -H 'Content-Type: application/json'
curl -sk -X POST 'https://petstore.swagger.io/v2/store/order' -d '{"complete":false,"id":1,"petId":1,"quantity":1,"shipDate":"test","status":"test"}' -H 'Content-Type: application/json'
```

After some time of debugging I found the issue in the `EnforceSingleContentType` function which sets the value of `Headers` variable to `nil`. This PR refactors the function and fixes the issue:

```bash
$ ./sj prepare -u https://petstore.swagger.io/v2/swagger.json -q -r 10 -H "CustomHeader: Hello" -H "Value: Test" -H "Another: One"

<SNIP>

curl -sk -X POST 'https://petstore.swagger.io/v2/user/createWithArray' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/json'
curl -sk -X POST 'https://petstore.swagger.io/v2/user/createWithList' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/json'
curl -sk -X GET 'https://petstore.swagger.io/v2/user/login?password=test&username=test' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/json'
curl -sk -X POST 'https://petstore.swagger.io/v2/pet/1/uploadImage' -d 'test=test' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: multipart/form-data'
curl -sk -X POST 'https://petstore.swagger.io/v2/pet' -d '<root><status>test</status><id>1</id><name>test</name><photoUrls>unknown_type_populate_manually</photoUrls><tags>unknown_type_populate_manually</tags></root>' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/xml'
curl -sk -X PUT 'https://petstore.swagger.io/v2/pet' -d '<root><status>test</status><id></id><name>test</name><photoUrls>unknown_type_populate_manually</photoUrls><tags>unknown_type_populate_manually</tags></root>' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/xml'
curl -sk -X GET 'https://petstore.swagger.io/v2/store/inventory' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/xml'
curl -sk -X POST 'https://petstore.swagger.io/v2/store/order' -d '{"complete":false,"id":1,"petId":1,"quantity":1,"shipDate":"test","status":"test"}' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/json'
curl -sk -X GET 'https://petstore.swagger.io/v2/store/order/1' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/json'
curl -sk -X PUT 'https://petstore.swagger.io/v2/user/test' -d '{"email":"test","firstName":"test","id":1,"lastName":"test","password":"test","phone":"test","userStatus":1,"username":"test"}' -H 'CustomHeader: Hello' -H 'Value: Test' -H 'Another: One' -H 'Content-Type: application/json'
```