### PR TITLE
Add curl command in verbose output for 'automate' mode

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -19,6 +19,7 @@ type VerboseResult struct {
 	Preview string `json:"preview"`
 	Status  int    `json:"status"`
 	Target  string `json:"target"`
+	Curl    string `json:"curl"`
 }
 
 var tempLogger *log.Logger

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -259,11 +259,18 @@ func (s SwaggerRequest) BuildDefinedRequests(client http.Client, method string, 
 			accessibleEndpoints = append(accessibleEndpoints, s.URL.String())
 		}
 		if strings.ToLower(outputFormat) != "console" {
+			curlCommand := fmt.Sprintf("curl -X %s -sk %s", method, s.URL.String())
+			if s.BodyData != nil {
+				curlCommand = fmt.Sprintf("%s -d '%s'", curlCommand, string(s.BodyData))
+			}
+			if len(Headers) != 0 {
+				curlCommand = fmt.Sprintf("%s -H '%s'", curlCommand, strings.Join(Headers, "' -H '"))
+			}
 			var result []byte
 			if getAccessibleEndpoints {
 				if sc == 200 {
 					if verbose {
-						result, _ = json.Marshal(VerboseResult{Method: method, Preview: resp[:tempResponsePreviewLength], Status: sc, Target: s.URL.String()})
+						result, _ = json.Marshal(VerboseResult{Method: method, Preview: resp[:tempResponsePreviewLength], Status: sc, Target: s.URL.String(), Curl: curlCommand})
 					} else {
 						result, _ = json.Marshal(Result{Method: method, Status: sc, Target: s.URL.String()})
 					}
@@ -275,7 +282,7 @@ func (s SwaggerRequest) BuildDefinedRequests(client http.Client, method string, 
 				}
 			} else {
 				if verbose {
-					result, _ = json.Marshal(VerboseResult{Method: method, Preview: resp[:tempResponsePreviewLength], Status: sc, Target: s.URL.String()})
+					result, _ = json.Marshal(VerboseResult{Method: method, Preview: resp[:tempResponsePreviewLength], Status: sc, Target: s.URL.String(), Curl: curlCommand})
 				} else {
 					result, _ = json.Marshal(Result{Method: method, Status: sc, Target: s.URL.String()})
 				}


### PR DESCRIPTION
This PR adds an extra field for curl command for easier reproduction when you run `sj automate` with verbose flag. Similar thing can be found in nuclei reports.

Before:
```bash
$ sj automate -v -u https://petstore.swagger.io/v2/swagger.json -q -r 10 -F json
INFO[0000] Sending requests at a rate of 10 requests per second.

{
  "apiTitle": "Swagger Petstore",
<SNIP>
  "results": [
    {
      "method": "GET",
      "preview": "[]",
      "status": 200,
      "target": "http://petstore.swagger.io/v2/pet/findByStatus?status=1"
    },
    {
      "method": "GET",
      "preview": "[]",
      "status": 200,
      "target": "http://petstore.swagger.io/v2/pet/findByTags?tags=1"
    }
<SNIP>
```

After:
```bash
$ ./sj automate -v -u https://petstore.swagger.io/v2/swagger.json -q -r 10 -F json
time="2025-03-13T04:49:32+05:00" level=info msg="Sending requests at a rate of 10 requests per second."

{
  "apiTitle": "Swagger Petstore",
<SNIP>
  "results": [
    {
      "method": "GET",
      "preview": "[]",
      "status": 200,
      "target": "http://petstore.swagger.io/v2/pet/findByStatus?status=1",
      "curl": "curl -X GET -sk http://petstore.swagger.io/v2/pet/findByStatus?status=1 -H 'Content-Type: application/json'"
    },
    {
      "method": "POST",
      "preview": "{\"code\":200,\"type\":\"unknown\",\"message\":\"1\"}",
      "status": 200,
      "target": "https://petstore.swagger.io/v2/user",
      "curl": "curl -X POST -sk https://petstore.swagger.io/v2/user -d '{\"email\":\"test\",\"firstName\":\"test\",\"id\":1,\"lastName\":\"test\",\"password\":\"test\",\"phone\":\"test\",\"userStatus\":1,\"username\":\"test\"}' -H 'Content-Type: application/json'"
    }
<SNIP>
```

This initially made me investigate what was wrong with the headers output :D