### PR TITLE
fix dublicate headers content-type in sj

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -681,7 +681,7 @@ func EnforceSingleContentType(newContentType string) {
 	newContentType = strings.TrimSpace(newContentType)
 
 	// Remove old 'Content-Type' header
-	slices.DeleteFunc(Headers, func(h string) bool {
+	Headers = slices.DeleteFunc(Headers, func(h string) bool {
 		return strings.HasPrefix(strings.ToLower(h), "content-type:")
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BishopFox/sj
 
-go 1.20
+go 1.21
 
 require (
 	github.com/getkin/kin-openapi v0.115.0


### PR DESCRIPTION
#### Card
The problem with duplicating headers due to incorrect use of the slices.DeleteFunc function, the signature of which says that we should get the result of its work at the output, and not wait for it in the original slice

#### Details
In 1.21 slices.DeleteFunc does not delete the line, but only shifts it towards the beginning and reduces the length of the array
Because of this, in sj there is a duplication of headers by the number of requests for each host
In other versions this does not happen, since the values ​​are deleted in the original slice