### PR TITLE
Prevent header-processing logic from dropping custom headers in 'automate' mode

### DIFF
--- a/cmd/requests.go
+++ b/cmd/requests.go
@@ -98,22 +98,19 @@ func MakeRequest(client http.Client, method, target string, timeout int64, reqDa
 			continue
 		}
 
-		key := Headers[i][:delimIndex]
-		value := Headers[i][delimIndex+1:]
+		key := strings.TrimSpace(Headers[i][:delimIndex])
+		value := strings.TrimSpace(Headers[i][delimIndex+1:])
 
-		if len(Headers) == 2 {
-			if key == "User-Agent" {
-				UserAgent = value
-			}
-			if key == "Content-Type" {
-				contentType = value
-			}
-			if key == "Accept" {
-				accept = value
-			}
-		} else {
-			req.Header.Set(key, value)
+		if key == "User-Agent" {
+			UserAgent = value
 		}
+		if key == "Content-Type" {
+			contentType = value
+		}
+		if key == "Accept" {
+			accept = value
+		}
+		req.Header.Set(key, value)
 	}
 
 	// User-Agent handling


### PR DESCRIPTION
In the current version, there is a bug where some custom headers are skipped when using multiple headers, like `User-Agent` and (custom) `Authorization` here:

```bash
❯ sj automate -p http://172.18.64.1:8081 -l /dev/shm/openapi.yaml -T http://127.0.0.1:5000 -A 'SomeUserAgent' -H 'Authorization: Bearer testtoken'

INFO[0000] Gathering API details.
<snip>
Title: Test API
# bearer token works
INFO Endpoint accessible!                          Method=GET Status=200 Target=/v1/health
INFO Endpoint accessible!                          Method=GET Status=200 Target=/v1/users
ERRO Endpoint not found.                           Method=GET Status=404 Target=/v1/users/bishopfox
# bearer token does not work
ERRO Unauthorized.                                 Method=POST Status=401 Target=/v1/echo
ERRO Unauthorized.                                 Method=GET Status=401 Target=/v1/ping
```

This is my dummy test API with 5 endpoints requiring authorization. As can be seen, last two endpoints respond with 401 status code because no token was sent. This PR fixes it:

```bash
❯ ./sj automate -p http://172.18.64.1:8081 -l /dev/shm/openapi.yaml -T http://127.0.0.1:5000 -A 'SomeUserAgent' -H 'Authorization: Bearer testtoken'

INFO[0000] Gathering API details.
<snip>
Title: Test API
INFO Endpoint accessible!                          Method=GET Status=200 Target=/v1/health
INFO Endpoint accessible!                          Method=GET Status=200 Target=/v1/users
ERRO Endpoint not found.                           Method=GET Status=404 Target=/v1/users/bishopfox
WARN Manual testing may be required.               Method=POST Status=400 Target=/v1/echo
INFO Endpoint accessible!                          Method=GET Status=200 Target=/v1/ping
```

