### PR TITLE
Fix HTTPBasic segfault and --quiet flag issues

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -45,20 +45,25 @@ func CheckSecuritySchemes(spec map[string]interface{}) {
 						if schemeType := scheme["scheme"]; schemeType != nil {
 							switch schemeType {
 							case "basic":
-								fmt.Println("Basic Authentication is accepted. Supply a username and password? (y/N)")
-								fmt.Scanln(&autoApplyBasicAuth)
-								autoApplyBasicAuth = strings.ToLower(autoApplyBasicAuth)
-								if autoApplyBasicAuth == "y" {
-									fmt.Printf("Enter a username.")
-									fmt.Scanln(&basicAuthUser)
-									fmt.Printf("Enter a password.")
-									fmt.Scanln(&basicAuthPass)
-									basicAuth = []byte(basicAuthUser + ":" + basicAuthPass)
-									basicAuthString = base64.StdEncoding.EncodeToString(basicAuth)
-									log.Infof("Using %s as the Basic Auth value.", basicAuthString)
-									Headers = append(Headers, "Authorization: Basic "+basicAuthString)
-								} else {
+								if quiet {
+									autoApplyBasicAuth = "n"
 									log.Warn("A basic authentication header is accepted. Review the spec and craft a header manually using the -H flag.")
+								} else {
+									fmt.Println("Basic Authentication is accepted. Supply a username and password? (y/N)")
+									fmt.Scanln(&autoApplyBasicAuth)
+									autoApplyBasicAuth = strings.ToLower(autoApplyBasicAuth)
+									if autoApplyBasicAuth == "y" {
+										fmt.Printf("Enter a username.")
+										fmt.Scanln(&basicAuthUser)
+										fmt.Printf("Enter a password.")
+										fmt.Scanln(&basicAuthPass)
+										basicAuth = []byte(basicAuthUser + ":" + basicAuthPass)
+										basicAuthString = base64.StdEncoding.EncodeToString(basicAuth)
+										log.Infof("Using %s as the Basic Auth value.", basicAuthString)
+										Headers = append(Headers, "Authorization: Basic "+basicAuthString)
+									} else {
+										log.Warn("A basic authentication header is accepted. Review the spec and craft a header manually using the -H flag.")
+									}
 								}
 							case "bearer":
 								log.Warn("A bearer token is accepted. Review the spec and craft a token manually using the -H flag.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ $ sj convert -u https://petstore.swagger.io/v2/swagger.json -o openapi.json`,
 			log.Error("Command not specified. See the --help flag for usage.")
 		}
 	},
-	Version: "2.3.0",
+	Version: "2.3.1",
 }
 
 func Execute() {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -198,7 +198,11 @@ func BuildRequestsFromPaths(spec map[string]interface{}, client http.Client) {
 							}
 						}
 
-						logURL, _ := url.Parse(targetURL)
+						logURL, parseErr := url.Parse(targetURL)
+						if parseErr != nil || logURL == nil {
+							log.Printf("Error parsing URL '%s': %v - skipping endpoint.", targetURL, parseErr)
+							continue
+						}
 						switch os.Args[1] {
 						case "automate":
 							var postBodyData string
@@ -403,7 +407,10 @@ func GenerateRequests(bodyBytes []byte, client http.Client) {
 	// Checks defined security schemes and prompts for authentication
 	CheckSecuritySchemes(spec)
 
-	u, _ := url.Parse(swaggerURL)
+	u, parseErr := url.Parse(swaggerURL)
+	if parseErr != nil {
+		u = &url.URL{}
+	}
 
 	// Gets the target server and base path from the specification file
 	if apiTarget == "" {


### PR DESCRIPTION
## Summary
SwaggerJacker v2.3.0 crashes with a segmentation fault when processing OpenAPI specs that use HTTPBasic authentication and the user declines to provide credentials.

## Environment
- **SwaggerJacker Version:** 2.3.0
- **OS:** macOS (Apple Silicon)
- **Go Version:** (`go1.25.7 darwin/arm64`) 
- **Install Method:** `go install github.com/BishopFox/sj@latest`

## Minimal Reproduction Case

### Spec File: `minimal_httpbasic_crash.json`
```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "HTTPBasic Crash Test",
    "version": "1.0.0"
  },
  "paths": {
    "/test": {
      "get": {
        "summary": "Test endpoint with HTTPBasic auth",
        "operationId": "test_endpoint",
        "security": [
          {
            "HTTPBasic": []
          }
        ],
        "responses": {
          "200": {
            "description": "Success"
          }
        }
      }
    }
  },
  "components": {
    "securitySchemes": {
      "HTTPBasic": {
        "type": "http",
        "scheme": "basic"
      }
    }
  }
}
```

### Command to Reproduce
```bash
echo "n" | sj automate --local-file minimal_httpbasic_crash.json --quiet --insecure -F json
```

## Expected Behavior
When `--quiet` flag is used, SwaggerJacker should either:
1. Skip authentication prompts entirely, OR
2. Handle declined authentication gracefully without crashing

## Actual Behavior
SwaggerJacker prompts for credentials (ignoring `--quiet` flag), then crashes with a segmentation fault:

```
  - HTTPBasic
Basic Authentication is accepted. Supply a username and password? (y/N) n
time="2026-02-25T21:16:18-06:00" level=warning msg="A basic authentication header is accepted. Review the spec and craft a header manually using the -H flag."
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x48 pc=0x104a93dc0]

goroutine 1 [running]:
github.com/BishopFox/sj/cmd.MakeRequest(...)
        /Users/me/go/pkg/mod/github.com/!bishop!fox/sj@v0.0.0-20260203221052-4c466112ee80/cmd/requests.go:63 +0x150
github.com/BishopFox/sj/cmd.BuildRequestsFromPaths(...)
        /Users/me/go/pkg/mod/github.com/!bishop!fox/sj@v0.0.0-20260203221052-4c466112ee80/cmd/utils.go:210 +0xd74
github.com/BishopFox/sj/cmd.GenerateRequests(...)
        /Users/me/go/pkg/mod/github.com/!bishop!fox/sj@v0.0.0-20260203221052-4c466112ee80/cmd/utils.go:474 +0x634
github.com/BishopFox/sj/cmd.init.func4(...)
        /Users/me/go/pkg/mod/github.com/!bishop!fox/sj@v0.0.0-20260203221052-4c466112ee80/cmd/automate.go:78 +0x404
```

## Root Cause Analysis
1. **Line 1:** SwaggerJacker detects HTTPBasic authentication in the spec
2. **Line 2:** Despite `--quiet` flag, it prompts user for credentials
3. **Line 3:** User responds "n" (no credentials)
4. **Line 4:** Warning is logged suggesting manual header crafting
5. **Line 5:** Nil pointer dereference occurs in `cmd/requests.go:63`

The crash suggests SwaggerJacker attempts to proceed with a nil authentication object, causing the segfault.

## Impact
- **Automated testing workflows:** Cannot use SwaggerJacker in CI/CD pipelines with specs that have HTTPBasic auth
- **Batch processing:** Scripts that process multiple specs fail when encountering HTTPBasic
- **User experience:** Unexpected crashes instead of graceful error handling

## Suggested Fixes

Attached as PR - Commit Message Covers Changes, adds check for quiet.

